### PR TITLE
Remove deprecated APIs, and use the latest webRTC APIs.

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -174,11 +174,11 @@ class Display extends React.Component {
     // video
     document.addEventListener('addRemoteVideo',
         function(e) {
-          var stream = e.detail.stream;
+          var streams = e.detail.streams;
           var remoteUserId = e.detail.userId;
 
           var temp = this.state.remoteVideos;
-          temp[remoteUserId] = window.URL.createObjectURL(stream);
+          temp[remoteUserId] = window.URL.createObjectURL(streams[0]);
           this.setState({
             remoteVideos: temp,
           });

--- a/library/peerconnection.js
+++ b/library/peerconnection.js
@@ -41,19 +41,13 @@ class CsioPeerConnection {
               +this.pc.iceConnectionState+' for '+this.userId});
       }
     }.bind(this);
-
-    // FIXME onAddStream deprecated, use tracks
     window.localStream.getTracks().forEach(function(track) {
       if (typeof this.pc.addTrack === 'function') {
         this.pc.addTrack(track, window.localStream);
         console.log(userId, 'added local stream with kind',track.kind);
       }
     },this);
-    this.pc.onaddstream = this.onRemoteStream.bind(this);
     this.pc.ontrack = this.onTrack.bind(this);
-  }
-
-  onTrack(event) {
   }
 
   // callable functions
@@ -132,10 +126,10 @@ class CsioPeerConnection {
   }
 
   // callback functions
-  onRemoteStream(e) {
-    console.log(this.userId, 'received remote stream');
+  onTrack(e) {
+    console.log(this.userId, 'received remote stream',e);
     modCommon.triggerEvent('addRemoteVideo',
-        {'pc': this.pc, 'userId': this.userId, 'stream': e.stream});
+        {'pc': this.pc, 'userId': this.userId, 'streams': e.streams});
     modCommon.triggerEvent('applicationLogEvent',
         {'pc': this.pc, 'eventLog': 'Remote stream received for '+this.userId});
   }

--- a/library/peerconnection.js
+++ b/library/peerconnection.js
@@ -127,7 +127,7 @@ class CsioPeerConnection {
 
   // callback functions
   onTrack(e) {
-    console.log(this.userId, 'received remote stream',e);
+    console.log(this.userId, 'received remote stream');
     modCommon.triggerEvent('addRemoteVideo',
         {'pc': this.pc, 'userId': this.userId, 'streams': e.streams});
     modCommon.triggerEvent('applicationLogEvent',

--- a/library/peerconnection.js
+++ b/library/peerconnection.js
@@ -42,10 +42,13 @@ class CsioPeerConnection {
       }
     }.bind(this);
 
-    // FIXME addStream, onAddStream deprecated, use tracks
-    this.pc.addStream(window.localStream);
-    console.log(userId, 'added local stream');
-
+    // FIXME onAddStream deprecated, use tracks
+    window.localStream.getTracks().forEach(function(track) {
+      if (typeof this.pc.addTrack === 'function') {
+        this.pc.addTrack(track, window.localStream);
+        console.log(userId, 'added local stream with kind',track.kind);
+      }
+    },this);
     this.pc.onaddstream = this.onRemoteStream.bind(this);
     this.pc.ontrack = this.onTrack.bind(this);
   }


### PR DESCRIPTION
https://app.clubhouse.io/callstatsio/story/926/remove-deprecated-apis-use-the-latest-webrtc-apis

**Remove deprecated APIs, use the latest webRTC APIs.**
- Removed addStream, and replaced it with addTrack.
- Removed onAddStream, and replaced it with ontrack.
- Remove createObjectURL, and replaced it with elem.srcObject.